### PR TITLE
added boba and 5irechain

### DIFF
--- a/docs/pages/supportedNetworks.mdx
+++ b/docs/pages/supportedNetworks.mdx
@@ -38,6 +38,8 @@ This is  the list of networks supported by our Bundlers & Paymaster.
 |Taiko|  | ✅ | 
 |Morph| ✅ |  | 
 |Sei| ✅ (Devnet) | ✅ | 
+|Boba| ✅ | ✅ |
+|5irechain| ✅ | ✅ |
 
 Need support for a new chain? Contact us [here](https://meetings-eu1.hubspot.com/biconomy/monika).
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add support for the `Boba` and `5irechain` networks in the documentation.

### Detailed summary
- Added support for `Boba` network
- Added support for `5irechain` network

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->