### PR TITLE
Mark Morph Mainnet as supported

### DIFF
--- a/docs/pages/smartAccountsV2/supportedNetworks.mdx
+++ b/docs/pages/smartAccountsV2/supportedNetworks.mdx
@@ -36,7 +36,7 @@ This is  the list of networks supported by our Bundlers & Paymaster.
 |X Layer| ✅ | ✅ | 
 |Tangle| ✅ | ✅ | 
 |Taiko|  | ✅ | 
-|Morph| ✅ |  | 
+|Morph| ✅ | ✅ | 
 |Sei| ✅ (Devnet) | ✅ | 
 |Boba| ✅ | ✅ |
 |5irechain| ✅ | ✅ |


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the support status of various networks in the `docs/pages/smartAccountsV2/supportedNetworks.mdx` file, specifically adding support for the `Morph` network in the second column.

### Detailed summary
- Updated `Morph` support status from "✅ | " to "✅ | ✅" indicating it is now supported in both columns.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->