### PR TITLE
removed ts-ignore

### DIFF
--- a/docs/pages/nexus-client/dan/index.md
+++ b/docs/pages/nexus-client/dan/index.md
@@ -64,7 +64,6 @@ await ownableDanClient.waitForUserOperationReceipt({ hash })
 
 // Prepare a user operation to withdraw 1 wei to userTwo
 // This demonstrates a simple transaction that requires multi-sig approval
-// @ts-ignore
 const withdrawalUserOp = await ownableDanClient.prepareUserOperation({
   calls: [
     {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the documentation for the `nexus-client` to provide a clearer example of preparing a user operation for a withdrawal transaction that requires multi-signature approval.

### Detailed summary
- Removed the `// @ts-ignore` comment from the example code.
- Clarified the purpose of the example as a demonstration of a simple transaction requiring multi-sig approval.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->