### PR TITLE
docs(supported-networks): Add OP testnet & mainnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 vocs.config.ts.timestamp*
 .env
+.vscode/

--- a/docs/pages/supportedNetworks.md
+++ b/docs/pages/supportedNetworks.md
@@ -2,17 +2,19 @@
 
 This is  the list of chains supported by Nexus.
 
-|Network | Testnet | Mainnet |   
-| --- | --- | --- |
-|Base | ✅ | ✅ |  
-|Ethereum | Coming soon | Coming soon |  
-|Polygon | Coming soon | Coming soon |  
-|BSC | Coming soon | Coming soon |  
-|Optimism | Coming soon | Coming soon |  
-|Avalanche | Coming soon | Coming soon |  
-|Gnosis | Coming soon | Coming soon |  
-|Arbitrum | Coming soon | Coming soon |  
+| Network            | Bundler     | Paymaster   |
+| ------------------ | ----------- | ----------- |
+| Base Testnet       | ✅           | ✅           |
+| Base Mainnet       | ✅           | ✅           |
+| OP Sepolia Testnet | ✅           | ✅           |
+| OP Mainnet         | ✅           | ✅           |
+| Ethereum           | Coming soon | Coming soon |
+| Polygon            | Coming soon | Coming soon |
+| BSC                | Coming soon | Coming soon |
+| Avalanche          | Coming soon | Coming soon |
+| Gnosis             | Coming soon | Coming soon |
+| Arbitrum           | Coming soon | Coming soon |
 
-This is the list of chains by Nexus( EntryPoint v7). You can find the list of supported networks by our Bundlers & Paymasters using EP v6 [here](/smartAccountsV2/supportedNetworks).
+> 💡 This is the list of chains for Nexus (EntryPoint v0.7.0). You can find the list of supported networks for our Bundlers & Paymasters using EntryPoint v0.6.0 [here](/smartAccountsV2/supportedNetworks).
 
 Need support for a new chain? Contact us [here](https://forms.gle/nycUAs3Fwyzz772w7).


### PR DESCRIPTION
- Add OP Sepolia & OP Mainnet to the supported networks table
- Changed the format of the table to differentiate between Bundler & Paymaster support as per our conversation @joepegler @filmakarov. Let's add two more columns for smart contracts and SDK after the next deployment
- Change the layout of the table a bit to accommodate the new format
 - Add `.vscode/` to `.gitignore`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for supported networks by Nexus, improving clarity and structure. It revises the format of the network table and updates references to the EntryPoint versions.

### Detailed summary
- Added `.vscode/` to `.gitignore`.
- Updated the network support table format in `docs/pages/supportedNetworks.md`.
- Changed the description to clarify the EntryPoint version from v7 to v0.7.0.
- Maintained the contact link for support without changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->