### PR TITLE
feat(nexus): :sparkles: Update supported networks list for nexus

### DIFF
--- a/docs/pages/supportedNetworks.md
+++ b/docs/pages/supportedNetworks.md
@@ -2,18 +2,22 @@
 
 This is  the list of chains supported by Nexus.
 
-| Network            | Bundler     | Paymaster   |
-| ------------------ | ----------- | ----------- |
-| Base Testnet       | ✅           | ✅           |
-| Base Mainnet       | ✅           | ✅           |
-| OP Sepolia Testnet | ✅           | ✅           |
-| OP Mainnet         | ✅           | ✅           |
-| Ethereum           | Coming soon | Coming soon |
-| Polygon            | Coming soon | Coming soon |
-| BSC                | Coming soon | Coming soon |
-| Avalanche          | Coming soon | Coming soon |
-| Gnosis             | Coming soon | Coming soon |
-| Arbitrum           | Coming soon | Coming soon |
+| Network                    | Bundler | Paymaster   |
+| -------------------------- | ------- | ----------- |
+| Base Mainnet               | ✅       | ✅           |
+| Base Testnet               | ✅       | ✅           |
+| OP Mainnet                 | ✅       | ✅           |
+| OP Sepolia Testnet         | ✅       | ✅           |
+| Ethereum Mainnet           | ✅       | Coming soon |
+| Ethereum Sepolia Testnet   | ✅       | Coming soon |
+| Polygon Mainnet            | ✅       | Coming soon |
+| Polygon Amoy Testnet       | ✅       | Coming soon |
+| BSC Mainnet                | ✅       | Coming soon |
+| BSC Testnet                | ✅       | Coming soon |
+| Gnosis Mainnet             | ✅       | Coming soon |
+| Arbitrum Mainnet           | ✅       | Coming soon |
+| Arbitrum Testnet           | ✅       | Coming soon |
+| 🐻 Berachain bArtio Testnet | ✅       | Coming soon |
 
 > 💡 This is the list of chains for Nexus (EntryPoint v0.7.0). You can find the list of supported networks for our Bundlers & Paymasters using EntryPoint v0.6.0 [here](/smartAccountsV2/supportedNetworks).
 


### PR DESCRIPTION
Add Bundler support for Ethereum Polygon, BSC, Gnosis, Arbitrum and Berachain bArtio

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for supported networks by Nexus, reorganizing the table and adding new entries to reflect the latest network statuses.

### Detailed summary
- Reorganized the table format for clarity.
- Added new networks: 
  - `Ethereum Mainnet`
  - `Ethereum Sepolia Testnet`
  - `Polygon Mainnet`
  - `Polygon Amoy Testnet`
  - `BSC Mainnet`
  - `BSC Testnet`
  - `Gnosis Mainnet`
  - `Arbitrum Mainnet`
  - `Arbitrum Testnet`
  - `🐻 Berachain bArtio Testnet`
- Changed the order of existing networks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->