### PR TITLE
chore: get user op receipt

### DIFF
--- a/docs/pages/nexus-client/methods/getUserOperationReceipt.md
+++ b/docs/pages/nexus-client/methods/getUserOperationReceipt.md
@@ -1,0 +1,34 @@
+# Get User Operation Receipt
+
+Returns the User Operation Receipt given a User Operation hash.
+
+**Usage Example**
+
+```typescript
+const receipt = await smartAccount.getUserOperationReceipt({
+    hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d'
+});
+
+// Example response
+{
+   blockHash: '0xaf1dadb8a98f1282e8f7b42cc3da8847bfa2cf4e227b8220403ae642e1173088',
+   blockNumber: 15132008n,
+   sender: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+   status: 'success',
+   // ... other receipt details
+}
+```
+
+**Parameters**
+
+- hash (`0x${string}`, required): A User Operation hash.
+
+**Returns**
+
+- `Promise<UserOperationReceipt>`: The User Operation receipt containing details such as:
+  - `blockHash`: The hash of the block where the operation was included
+  - `blockNumber`: The number of the block where the operation was included
+  - `sender`: The address that sent the operation
+  - `status`: The status of the operation ('success' | 'reverted')
+
+[Reference: Viem getUserOperationReceipt](https://viem.sh/account-abstraction/actions/bundler/getUserOperationReceipt) 

--- a/docs/pages/nexus-client/methods/index.md
+++ b/docs/pages/nexus-client/methods/index.md
@@ -209,6 +209,7 @@ const userOpReceipt: UserOpReceipt = await smartAccount.sendTransactionWithExecu
 - [estimateUserOperationGas](/nexus-client/methods/estimateUserOperationGas) - Estimate gas values for a User Operation
 - [getUserOperation](/nexus-client/methods/getUserOperation) - Get information about a User Operation
 - [debugUserOperation](/nexus-client/methods/debugUserOperation) - Debug a User Operation with detailed information
+- [getUserOperationReceipt](/nexus-client/methods/getUserOperationReceipt) - Get the User Operation Receipt given a User Operation hash
 
 ## Network Methods
 - [getSupportedEntryPoints](/nexus-client/methods/getSupportedEntryPoints) - Get supported EntryPoints


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `getUserOperationReceipt` method to the documentation, providing details on how to retrieve a User Operation Receipt using a hash. It enhances the existing documentation by adding usage examples, parameters, and return values.

### Detailed summary
- Added `getUserOperationReceipt` to the methods index.
- Created a new documentation page for `getUserOperationReceipt`.
- Included a usage example in TypeScript.
- Defined parameters and return types for the method.
- Added a reference link to the `getUserOperationReceipt` in Viem documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->