### PR TITLE
Broken Link Removal

### DIFF
--- a/docs/pages/smartAccountsV2/tutorials/utils/transferOwnership.md
+++ b/docs/pages/smartAccountsV2/tutorials/utils/transferOwnership.md
@@ -3,7 +3,7 @@
 This tutorial provides insights into how to transfer the ownership of a smart account.
 
 :::caution
-Transfer Ownership is performed within the framework of either the [ECDSA Ownership Module](https://docs.biconomy.io/modules/ecdsa) or the [Multichain Validation Module](https://docs.biconomy.io/modules/multichain). If you are utilizing the [Session Key Manager](https://docs.biconomy.io/modules/sessions/sessionvalidationmodule), you will need to **recreate the smart account client with the new owner** (new signer). This involves specifying the smart account address and recreating the session. 
+Transfer Ownership is performed within the framework of either the [ECDSA Ownership Module] or the [Multichain Validation Module]. If you are utilizing the [Session Key Manager], you will need to **recreate the smart account client with the new owner** (new signer). This involves specifying the smart account address and recreating the session. 
 :::
 
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `transferOwnership.md` documentation to correct the formatting of module links and adds a note about the importance of specifying the `accountAddress` parameter when executing `transferOwnership()`.

### Detailed summary
- Removed the hyperlinks from the text in the caution note for the `ECDSA Ownership Module` and `Multichain Validation Module`.
- Added a clarification regarding the necessity of specifying the `accountAddress` parameter after executing `transferOwnership()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->